### PR TITLE
Makefile: use gcc -M flags to get complete DAG on recompiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .*.swp
 *.o
+*.d
 castty
 events.js

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 CC = gcc
-CFLAGS = -O2 -I/usr/local/include -Wall -Wextra -Wshadow -std=c11
+CFLAGS = -O2 -I/usr/local/include -Wall -Wextra -Wshadow -std=c11 -MMD -MP
 
 TARGET = castty
+OBJ := audio.o castty.o input.o output.o shell.o xwrap.o
 
 all: $(TARGET)
 
-castty: audio.o castty.o input.o output.o shell.o xwrap.o
+castty: $(OBJ)
 	$(CC) $(CFLAGS) -o castty $^ -L/usr/local/lib -lsoundio -lpthread -lmp3lame
 
 clean:
-	rm -f *.o $(TARGET) 
+	rm -f *.o *.d $(TARGET)
+
+-include $(OBJ:.o=.d)


### PR DESCRIPTION
This patch allows the Makefile to see a complete DAG on recompiles so
that, for example, changes to the headerfile castty.h will cause all
objects of source files including that header to get re-compiled.

Obviously on the first run of make this will not be the case, however,
on the first run this doesn't matter.

This patch makes use of some gnu make specific features, however, the
original makefile already made the assumption of gnu make.