### PR TITLE
Fix _BSD_SOURCE deprecation warning and _XOPEN_SOURCE with glibc

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -1,4 +1,4 @@
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/shell.c
+++ b/shell.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE
+#define _XOPEN_SOURCE 500
 #include <sys/ioctl.h>
 
 #include <stdio.h>


### PR DESCRIPTION
This patch fixes deprecation warnings given by glibc when using
_BSD_SOURCE and defines _XOPEN_SOURCE to 500 to provide prototypes for
grantpt, unlockpt and ptsname.

When using glibc version 2.24 a deprecation warning is given for the use
of _BSD_SOURCE and a recommendation is made to use _DEFAULT_SOURCE.

Additionally, defining _XOPEN_SOURCE is not enough to get prototypes for
grantpt, unlockpt and ptsname. It has to be defined to at least 500
before gcc stops producing warnings about implicit function
declarations. (This also causes castty to crash because it assumes
ptsname returns int.)