### PR TITLE
audio.c: Fix use of uninitialised "lame" when not using mp3

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -70,7 +70,7 @@ static void *
 writer(void *priv)
 {
 	unsigned char *mp3buf = NULL;
-	lame_t lame;
+	lame_t lame = NULL;
 
 	(void)priv;
 
@@ -179,10 +179,12 @@ writer(void *priv)
 		}
 	}
 
-	int blen = lame_encode_flush(lame, mp3buf, MP3_BUF_SIZE);
-	fwrite(mp3buf, 1, blen, ctx.fout);
+	if (mp3) {
+		int blen = lame_encode_flush(lame, mp3buf, MP3_BUF_SIZE);
+		fwrite(mp3buf, 1, blen, ctx.fout);
 
-	lame_close(lame);
+		lame_close(lame);
+	}
 
 	return NULL;
 }

--- a/audio.c
+++ b/audio.c
@@ -184,6 +184,7 @@ writer(void *priv)
 		fwrite(mp3buf, 1, blen, ctx.fout);
 
 		lame_close(lame);
+		free(mp3buf);
 	}
 
 	return NULL;


### PR DESCRIPTION
Fix uninitialised use of variable `lame` in function writer when mp3
output is not enabled. Additionally, lame_close was also being called on
a potentially uninitialised value.

Since libmp3lame handles passing a NULL to any of its functions
gracefully (although this is not documented), the variable `lame` is now
also initialised to NULL, this also prevents future accidents where
calls to libmp3lame functions are not guarded with an if (mp3).

Finally, this also silences a gcc warning about potentially
uninitialised use of the variable `lame`.