### PR TITLE
Get rid of scattered feature test macro definitions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
 CC = gcc
-CFLAGS = -O2 -I/usr/local/include -Wall -Wextra -Wshadow -std=c11 -MMD -MP
 
-TARGET = castty
+WARNINGS := -Wall -Wextra -Wshadow
+
+CPPFLAGS = -I/usr/local/include
+CFLAGS = -O2 -std=c11 -MMD -MP $(WARNINGS)
+LDFLAGS = -L/usr/local/lib
+LDLIBS = -lsoundio -lpthread -lmp3lame
+
+TARGET := castty
 OBJ := audio.o castty.o input.o output.o shell.o xwrap.o
 
 all: $(TARGET)
-
-castty: $(OBJ)
-	$(CC) $(CFLAGS) -o castty $^ -L/usr/local/lib -lsoundio -lpthread -lmp3lame
+$(TARGET): $(OBJ)
 
 clean:
-	rm -f *.o *.d $(TARGET)
+	$(RM) $(OBJ) $(OBJ:.o=.d) $(TARGET)
 
 -include $(OBJ:.o=.d)
+
+.PHONY: all clean

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 
 WARNINGS := -Wall -Wextra -Wshadow
 
-CPPFLAGS = -I/usr/local/include
+CPPFLAGS = -I/usr/local/include -D_XOPEN_SOURCE=600
 CFLAGS = -O2 -std=c11 -MMD -MP $(WARNINGS)
 LDFLAGS = -L/usr/local/lib
 LDLIBS = -lsoundio -lpthread -lmp3lame

--- a/audio.c
+++ b/audio.c
@@ -1,4 +1,3 @@
-#define _DEFAULT_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/castty.c
+++ b/castty.c
@@ -1,5 +1,3 @@
-#define _XOPEN_SOURCE 600
-
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>

--- a/shell.c
+++ b/shell.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 500
 #include <sys/ioctl.h>
 
 #include <stdio.h>


### PR DESCRIPTION
This PR cleans up the Makefile a bit and replaces the scattered  feature test macro definitions and and replaces them with a -D_XOPEN_SOURCE in the Makefile.