### PR TITLE
castty: Don't close stdin of subchild on SIGCHLD (fixes #25)

### DIFF
--- a/src/castty.c
+++ b/src/castty.c
@@ -84,7 +84,7 @@ handle_sigchld(int sig)
 	(void)sig;
 
 	while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
-		if (pid == child || pid == subchild) {
+		if (pid == child) {
 			close(STDIN_FILENO);
 		}
 	}


### PR DESCRIPTION
outputproc already closes stdin before going into its poll loop, this
means that when the SIGCHLD handler closes stdin for subchild, it ends
up closing an already closed fd.

Additionally, on my system using pulseaudio, this was closing the read
end of an internal pulseaudio pipe causing a stacktrace on exit. This
fixes #25.