### PR TITLE
 ui/js/player.js: Quick and dirty support for on-screen annotations.

### DIFF
--- a/ui/asciicast-annot.js
+++ b/ui/asciicast-annot.js
@@ -1,0 +1,32 @@
+// This is normal asciinema v1 recording with "var data =" line prepended.
+var data =
+{
+  "duration": 10.0,
+  "env": {
+    "TERM": "xterm",
+    "SHELL": "/bin/bash"
+  },
+  "version": 1,
+  "title": "dumb sample asciicast",
+  "height": 24,
+  "command": null,
+  "width": 80,
+  "annotations": [
+    {at:0.5, dur: 1, relx: 0.1, rely: 0.1, text: "annotation #1"},
+    {at:3.0, dur: 3, relx: 0.8, rely: 0.8, text: "annotation\n#2"}
+  ],
+  "stdout": [
+    [
+      0,
+      "Just"
+    ],
+    [
+      0.5,
+      " a dumb"
+    ],
+    [
+      3.0,
+      " sample asciicast.\r\n"
+    ],
+  ]
+}

--- a/ui/index-annotations.html
+++ b/ui/index-annotations.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title></title>
+		<link rel="stylesheet" href="css/min.css" />
+		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+		<style>
+			#controls {
+				background: #000;
+			}
+			button {
+				color: #fff;
+				background: none;
+				border: none;
+				font-size: 13pt;
+				height: 30px;
+				width: 3%;
+				margin: 0 0 0 2px;
+			}
+			button:focus {
+			    outline: none;
+			}
+                        .rangeslider--horizontal {
+                                margin: 8px 2% 0 1%;
+                                float:right;
+                                width: 93%;
+                        }
+		</style>
+		<script src="js/min.js"></script>
+		<script src="js/player.js"></script>
+	</head>
+	<body>
+		<div id="container"></div>
+		<!-- The file below is a normal asciinema recording
+		     with "var data =" line prepended. -->
+		<script src="asciicast-annot.js"></script>
+		<script>
+			// You can pass null instead of audio
+			var p = player(null, $("#container"), data);
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
It's a mystery for me why asciinema doesn't support on-screen annotations. Thanks for putting up an alternative player written in non-obscure language (as much as JS can be called that).

I'm going to submit RFC for inclusion of annotations in asciinema v2 format, referring to this PR.