### PR TITLE
Make available audio device listing directly usable & disambiguate audio format

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -558,10 +558,9 @@ audio_list_inputs(void)
 			soundio_device_unref(dev);
 			continue;
 		}
-
-		printf("%4d: %s %dHz\n"
-		    "      castty -d '%s' -a audio.%s\n", i, dev->name, rate,
-		    dev->id, soundio_format_string(fmt));
+		printf("%4d: %s, %dHz, format: '%s'\n"
+		    "      castty record -d '%s' -a audio.raw\n", i, dev->name, rate,
+		    soundio_format_string(fmt), dev->id);
 		soundio_device_unref(dev);
 	}
 


### PR DESCRIPTION
On my Chromebook, castty currently shows the following when asked to display potential audio capture devices:

```
$ castty record -l
Available input devices:
   0: Monitor of Intel 82801AA-ICH 44100Hz
      castty -d 'alsa_output.hw_0_0.monitor' -a audio.float 32-bit LE
   1: Intel 82801AA-ICH 44100Hz
      castty -d 'alsa_input.hw_0_0' -a audio.float 32-bit LE
```

The call to `soundio_format_string` is returning a string which isn't useful as a filename suffix, *especially* when the tool suggested to post-process audio files (sox) relies heavily on filename suffixes.

This commit changes the output listing:
- The `castty` invocation displayed is made cut'n'paste-able by including the ubiquitous `record` sub-command
- The audio filename suffix in the is hardcoded to `raw`, which allows `sox` to /attempt/ to process it (subject to more params being provided to it)
- The audio format is moved to the device summary line, making it clear that it's not part of the cut'n'paste command invocation, and providing info for subsequent `sox` invocations.

Here's the result on my machine:

```
$ castty record -l
Available input devices:
   0: Monitor of Intel 82801AA-ICH, 44100Hz, format: 'float 32-bit LE'
      castty record -d 'alsa_output.hw_0_0.monitor' -a audio.raw
   1: Intel 82801AA-ICH, 44100Hz, format: 'float 32-bit LE'
      castty record -d 'alsa_input.hw_0_0' -a audio.raw
```